### PR TITLE
Update http dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,9 +35,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "http"
-version = "0.2.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "libc"
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "retry-after"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retry-after"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Joe Wilm <joe@jwilm.com>"]
 description = "Retry-After header for Hyper's header module"
 license = "MIT OR Apache-2.0"
@@ -11,5 +11,5 @@ edition = "2018"
 
 [dependencies]
 chrono = "0.4"
-http = "0.2"
+http = "1"
 thiserror = "1"


### PR DESCRIPTION
This updates the `http` dependency to 1.1, and bumps the crate version.